### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/fareedroshan01/0c426ed1-0e7b-4944-bacd-fe4406a14260/a8fbc738-5f71-4883-bfc9-564e81117ed3/_apis/work/boardbadge/ada06bf0-524e-4cc7-84a1-69f829b52a1a)](https://dev.azure.com/fareedroshan01/0c426ed1-0e7b-4944-bacd-fe4406a14260/_boards/board/t/a8fbc738-5f71-4883-bfc9-564e81117ed3/Microsoft.RequirementCategory)
 # Automate Your Life with Python
 This repository contains scripts of my course "Automate Your Life with Python": https://www.udemy.com/course/automate-your-life-with-python/?referralCode=7FA8B361D7A92B03A8C3
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/fareedroshan01/0c426ed1-0e7b-4944-bacd-fe4406a14260/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.